### PR TITLE
Update 0prometheus-operator-deployment.yaml

### DIFF
--- a/manifests/0prometheus-operator-deployment.yaml
+++ b/manifests/0prometheus-operator-deployment.yaml
@@ -21,6 +21,7 @@ spec:
         - --logtostderr=true
         - --config-reloader-image=carlosedp/configmap-reload:v0.2.2
         - --prometheus-config-reloader=carlosedp/prometheus-config-reloader:v0.28.0
+        - --prometheus-default-base-image=carlosedp/prometheus
         image: carlosedp/prometheus-operator:v0.28.0
         name: prometheus-operator
         ports:


### PR DESCRIPTION
Add base image. 2/3 pods will fail to start without also specifying the base image.